### PR TITLE
Fix for numeric session names

### DIFF
--- a/src/MadelineProtoExtensions/SystemApiExtensions.php
+++ b/src/MadelineProtoExtensions/SystemApiExtensions.php
@@ -100,8 +100,8 @@ final class SystemApiExtensions
 
             $sessions[$session] = [
                 'session' => $session,
-                'file' => Files::getSessionFile($session),
-                'status' => $status,
+                'file'    => Files::getSessionFile((string)$session),
+                'status'  => $status,
             ];
         }
 


### PR DESCRIPTION
[error] TelegramApiServer\Files::getSessionFile(): Argument #1 ($session) must be of type ?string, int given, called in /app-host-link/src/MadelineProtoExtensions/SystemApiExtensions.php on line 103