### PR TITLE
fix: accept full TCP port range when stripping port from remote address

### DIFF
--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -102,7 +102,7 @@ final class Server
             $hostArray = \explode(':', $remote);
             if (\count($hostArray) >= 2) {
                 $port = (int) \array_pop($hostArray);
-                if ($port > 0 && $port <= 65353) {
+                if ($port > 0 && $port <= 65535) {
                     $remote = \implode(':', $hostArray);
                 }
             }


### PR DESCRIPTION
## Summary

`Server::getClientIp()` is supposed to strip the source port from the client's `ip:port` remote address before the IP is matched against `IP_WHITELIST`. The range check uses `65353` instead of `65535`:

https://github.com/xtrime-ru/TelegramApiServer/blob/master/src/Server/Server.php#L105

```php
$port = (int) \array_pop($hostArray);
if ($port > 0 && $port <= 65353) {
    $remote = \implode(':', $hostArray);
}
```

Whenever the kernel/docker-proxy picks an ephemeral source port in `65354–65535`, the port is left attached to the address and the literal `"ip:port"` value reaches `isIpAllowed()`, which compares strictly against the whitelist:

```
Your host is not allowed: 10.10.0.2:65428
```

`10.10.0.2` is whitelisted, but the rejection happens because `65428 > 65353`. The bug is intermittent and looks like a flaky whitelist depending on which source port is assigned.

## Fix

One-line change: extend the upper bound to the actual TCP port maximum (`65535`).

## Test plan

- [ ] Manual: from a whitelisted host, hammer the API repeatedly until the client picks a source port in the affected range and confirm the request succeeds (before the fix it rejects).
- [ ] No behavioural change for ports `1–65353`.